### PR TITLE
Fix GitHub emoji in !source command

### DIFF
--- a/src/commands/misc/source-command.js
+++ b/src/commands/misc/source-command.js
@@ -53,7 +53,7 @@ class SourceCommand extends Command {
             fields: [
                 {
                     name: 'Contribute',
-                    value: `Check out the source code on [github](${home})! :github:`
+                    value: `Check out the source code on [github](${home})! <:github:710221621469642808>`
                 },
                 {
                     name: 'License',


### PR DESCRIPTION
You need the full tag like to for custom emojis to work in embeds. Same issue as https://github.com/Rapptz/discord.py/issues/390. The emoji *should*™️  show up correctly now